### PR TITLE
Adapt to updated monasca-grafana-plugin

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -102,7 +102,13 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 		}
 	}
 
-	keystoneAuth := ds.JsonData.Get("keystoneAuth").MustBool()
+	keystoneAuth := ds.JsonData.Get("keystoneAuth").MustBool(false)
+
+	// Try authType (new setting name) as well if keystoneAuth is missing/false
+	if !keystoneAuth {
+		keystoneAuth = (ds.JsonData.Get("authMode").MustString("") == "Keystone")
+	}
+
 	if keystoneAuth {
 		token, err := keystone.GetToken(c)
 		if err != nil {


### PR DESCRIPTION
This commit adds (backwards compatible) support for the new
auth mechanism selection mechanism introduced in
monasca-grafana-datasource by

  https://github.com/openstack/monasca-grafana-datasource/commit/bb5178406c03d37a957b64ef59c61ecdec504fc3

Note: the `monasca-grafana-datasource` commit in question has recently been [reverted](https://review.openstack.org/#/c/529620/) because it breaks without the code from this pull
request in Grafana. I tested this pull request with both the reverted and the unreverted state and it works.
