### PR TITLE
cli: avoid rely on response.ContentLength (#13120)

### DIFF
--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -150,7 +150,7 @@ func downloadFile(pluginName, filePath, url string) (err error) {
 		return err
 	}
 
-	r, err := zip.NewReader(bytes.NewReader(body), resp.ContentLength)
+	r, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
response.ContentLength might be invalid if the http response
is chunked.
(cherry picked from commit c53d7ad47cefd2b258bdb7784defbfb9d6100c16)
