### PR TITLE
Expire granafa session when cookies expire.

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -112,7 +112,11 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 	if keystoneAuth {
 		token, err := keystone.GetToken(c)
 		if err != nil {
-			c.JsonApiErr(500, "Failed to get keystone token", err)
+			c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/", nil, middleware.IsSecure(c), true)
+			c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/", nil, middleware.IsSecure(c), true)
+			c.SetCookie(middleware.SESS_KEY_PASSWORD, "", -1, setting.AppSubUrl+"/", nil, middleware.IsSecure(c), true)
+			c.Session.Destory(c)
+			c.JsonApiErr(500, "Failed to get keystone token. Reload page!", err)
 			return
 		}
 		c.Req.Request.Header["X-Auth-Token"] = []string{token}


### PR DESCRIPTION
At the moment, grafana session expires after 7 days by default. On the
other hand, keystone token usually expires earlier. This leads to all
the panels reporting "Failed to obtain Keystone token" warning message
while the user remains logged in to grafana dashboard. Ideally, the
token would be renewed automatically but since the cookie containing the
password expires, this is not possible. Hence, logging out the user is
the best options which happens automatically after expiring the grafana
session which is in essence what this commit does.

Closes: #6

* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUST**
