### PR TITLE
Update grunt-sass library (#11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-ng-annotate": "^3.0.0",
     "grunt-notify": "^0.4.5",
     "grunt-postcss": "^0.8.0",
-    "grunt-sass": "^1.2.1",
+    "grunt-sass": "^2.1.0",
     "grunt-string-replace": "~1.3.1",
     "grunt-systemjs-builder": "^0.2.7",
     "grunt-usemin": "3.1.1",


### PR DESCRIPTION
This updated is needed because current version of this library is incompatible with nodejs 10

nodejs10 upgrade change:
https://review.opendev.org/#/c/695459/
This version is also used in monasca-grafana :
https://github.com/monasca/monasca-grafana/blob/master/package.json#L4

(cherry picked from commit 1f98a5b)